### PR TITLE
feature/build_binary: Added GH workflow for building and pushing binary to release

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -1,0 +1,56 @@
+name: Publish binary to release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up GO
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: Install make
+        run: |
+          apt install make -y
+
+      - name: Build strided binary
+        run: |
+          make install
+          make build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: strided
+          path: build/strided
+
+  publish:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: strided
+
+      - name: Set tag output
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          name: Release ${{ steps.vars.outputs.tag }}
+          files: ${{ steps.download.outputs.download-path }}/strided


### PR DESCRIPTION
## Context and purpose of the change

I've added a GitHub workflow that builds and pushes stride binary to release.
It is simple to use - when pushing the tag to the repo, workflow automatically builds the binary and puts it to `Assets` on the release page.




